### PR TITLE
style: tweak tile icon margins

### DIFF
--- a/src/components/SkillTile.js
+++ b/src/components/SkillTile.js
@@ -48,7 +48,7 @@ const SkillTile = ({ name, rating, iconName }) => {
     >
       <div
         css={css`
-          margin-right: 0.25em;
+          margin: 0 0.25em 0 1em;
         `}
       >
         <Icon name={iconName} viewbox="0 0 128 128" size="2em" />


### PR DESCRIPTION
## Description

Tweaks margins on skill icons in skill tiles for nicer look ¯\_(ツ)_/¯

## Related

Closes

## Screenshot(s)

**Before**
![2023-08-16_11-16-57](https://github.com/roadlittledawn/portfolio-site/assets/2952843/8bbb43bc-de92-4082-8249-58e5a8e28f94)

**After**
![2023-08-16_11-16-40](https://github.com/roadlittledawn/portfolio-site/assets/2952843/c99fbf77-5f1e-482b-86ba-d8c456f99c13)
