### PR TITLE
Fix: Add View Transitions and persist ScrabbleLogo animation

### DIFF
--- a/src/components/FilterNav.astro
+++ b/src/components/FilterNav.astro
@@ -136,7 +136,7 @@ const {
 
 <script>
   // This script handles the filtering logic
-  document.addEventListener('DOMContentLoaded', function() {
+  function initializeFilters() {
     const filterBtns = document.querySelectorAll('.filter-btn');
     const viewBtns = document.querySelectorAll('.view-btn');
     const levelFilter = document.getElementById('level-filter');
@@ -363,5 +363,15 @@ const {
     if (initialFocus !== 'all' || initialLevel !== 'all' || initialSort !== 'name-asc') {
       applyFiltersAndSort();
     }
-  });
+  }
+
+  // Initialize on DOMContentLoaded (for initial page load)
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeFilters);
+  } else {
+    initializeFilters();
+  }
+
+  // Re-initialize after Astro page transitions
+  document.addEventListener('astro:page-load', initializeFilters);
 </script>


### PR DESCRIPTION
## Summary
- Added Astro View Transitions for smoother navigation
- Fixed ScrabbleLogo to animate only on initial load/refresh
- Updated FilterNav to work with View Transitions

## Changes
1. **Added ViewTransitions to BaseLayout**
   - Imported and added `<ViewTransitions />` component
   - Added `transition:persist` to ScrabbleLogo

2. **Updated ScrabbleLogo animation logic**
   - Logo animates on initial page load and browser refresh
   - Logo persists without re-animating during client-side navigation
   - Prevents tile position shifts on route changes

3. **Fixed FilterNav compatibility**
   - Wrapped initialization in `initializeFilters` function
   - Added `astro:page-load` event listener for View Transitions
   - Maintains backward compatibility with regular page loads

## Test Plan
- [x] Verify ScrabbleLogo animates on initial page load
- [x] Verify ScrabbleLogo persists without animation on route changes
- [x] Verify ScrabbleLogo animates again on browser refresh
- [x] Test filtering functionality on skills page works after navigation
- [x] Test view toggle (Grid/Category) works after navigation

🤖 Generated with Claude Code