### PR TITLE
chore: update sync workflow to create PR instead of direct push

### DIFF
--- a/.github/workflows/sync-career-data.yml
+++ b/.github/workflows/sync-career-data.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * 0' # Weekly on Sunday at midnight UTC
   workflow_dispatch: # Manual trigger
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   sync-data:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Updates sync-career-data workflow to create a PR instead of pushing directly to develop
- Adds explicit permissions (`contents: write`, `pull-requests: write`) for the GITHUB_TOKEN
- Respects branch protection rules on develop

## Changes
- Replaces direct `git push` with `peter-evans/create-pull-request@v6` action
- PR will be created from `chore/sync-career-data` branch to `develop`
- Branch auto-deletes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)