### PR TITLE
fix: add CI-specific sync script to avoid .env dependency

### DIFF
--- a/.github/workflows/sync-career-data.yml
+++ b/.github/workflows/sync-career-data.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GRAPHQL_ENDPOINT: ${{ secrets.GRAPHQL_ENDPOINT }}
           GRAPHQL_API_KEY: ${{ secrets.GRAPHQL_API_KEY }}
-        run: npm run sync-data
+        run: npm run sync-data:ci
         continue-on-error: true
         id: sync
         

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "sync-data": "node --env-file=.env scripts/sync-career-data.js"
+    "sync-data": "node --env-file=.env scripts/sync-career-data.js",
+    "sync-data:ci": "node scripts/sync-career-data.js"
   },
   "dependencies": {
     "astro": "^4.0.0"


### PR DESCRIPTION
## Summary
- Add `sync-data:ci` npm script that runs without `--env-file` flag
- Update workflow to use the CI script, fixing ".env not found" error
- Local development still uses `sync-data` with `.env` file

## Test plan
- [ ] Manually trigger the sync-career-data workflow and verify it no longer errors on missing .env
- [ ] Verify `npm run sync-data` still works locally with .env file

🤖 Generated with [Claude Code](https://claude.ai/claude-code)