### PR TITLE
fix: use personal access token instead of GH token to trigger pr-validation workflow

### DIFF
--- a/.github/workflows/sync-career-data.yml
+++ b/.github/workflows/sync-career-data.yml
@@ -47,7 +47,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         id: create-pr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           branch: chore/sync-career-data
           base: develop
           title: "chore: update career data from API"


### PR DESCRIPTION
The issue is that the sync-career-data.yml workflow uses GITHUB_TOKEN to create the PR, which
prevents other workflows from triggering. This is a GitHub security feature - workflows 
triggered by GITHUB_TOKEN don't trigger additional workflow runs to prevent recursive workflow 
execution.