### PR TITLE
Fix admin auth: use server-side middleware with HTTP-only cookies

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -25,6 +25,7 @@
         "npm:clsx@^2.1.1",
         "npm:graphql-request@^6.1.0",
         "npm:graphql@^16.9.0",
+        "npm:isomorphic-dompurify@^2.35.0",
         "npm:jsonwebtoken@^9.0.3",
         "npm:marked@^15.0.6",
         "npm:react-dom@^18.3.1",

--- a/netlify/functions/ai-assistant.js
+++ b/netlify/functions/ai-assistant.js
@@ -35,8 +35,17 @@ export const handler = async (event, context) => {
     };
   }
 
-  // Authentication check
-  const authToken = event.headers.authorization?.replace('Bearer ', '');
+  // Authentication check - get token from cookie
+  let authToken;
+  if (event.headers.cookie) {
+    const cookies = event.headers.cookie.split(';').reduce((acc, cookie) => {
+      const [key, value] = cookie.trim().split('=');
+      acc[key] = value;
+      return acc;
+    }, {});
+    authToken = cookies.auth_token;
+  }
+  
   if (!isAuthenticated(authToken)) {
     return {
       statusCode: 401,

--- a/netlify/functions/auth-login.js
+++ b/netlify/functions/auth-login.js
@@ -84,11 +84,18 @@ export const handler = async (event, context) => {
       }
     );
 
+    // Set HTTP-only cookie (Secure only in production)
+    const isProduction = process.env.CONTEXT === 'production' || process.env.NODE_ENV === 'production';
+    const cookieHeader = `auth_token=${token}; HttpOnly; ${isProduction ? 'Secure; ' : ''}SameSite=Lax; Path=/; Max-Age=86400`;
+
     return {
       statusCode: 200,
-      headers,
+      headers: {
+        ...headers,
+        'Set-Cookie': cookieHeader,
+      },
       body: JSON.stringify({
-        token,
+        success: true,
         user: {
           username: adminUsername,
         },

--- a/netlify/functions/auth-logout.js
+++ b/netlify/functions/auth-logout.js
@@ -26,13 +26,16 @@ export const handler = async (event, context) => {
     };
   }
 
-  // For JWT, logout is client-side (remove token)
-  // This endpoint is mainly for consistency and potential future use
-  // (e.g., token blacklist)
+  // Clear the auth cookie (Secure only in production)
+  const isProduction = process.env.CONTEXT === 'production' || process.env.NODE_ENV === 'production';
+  const cookieHeader = `auth_token=; HttpOnly; ${isProduction ? 'Secure; ' : ''}SameSite=Lax; Path=/; Max-Age=0`;
 
   return {
     statusCode: 200,
-    headers,
+    headers: {
+      ...headers,
+      'Set-Cookie': cookieHeader,
+    },
     body: JSON.stringify({
       message: 'Logged out successfully',
     }),

--- a/src/components/admin/ai/AIChatPanel.tsx
+++ b/src/components/admin/ai/AIChatPanel.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef, useEffect } from 'react';
-import { getAuthToken } from '../../../lib/auth';
 
 interface Message {
   role: 'user' | 'assistant';
@@ -47,11 +46,6 @@ export default function AIChatPanel({
     setIsLoading(true);
 
     try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('Not authenticated');
-      }
-
       const claudeMessages = newMessages.map((msg) => ({
         role: msg.role,
         content: msg.content,
@@ -61,8 +55,8 @@ export default function AIChatPanel({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
         },
+        credentials: 'include', // Include cookies
         body: JSON.stringify({
           messages: claudeMessages,
           context: {

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -13,11 +13,9 @@
 
 export interface Props {
   title: string;
-  /** Set to true to skip auth check (for login page) */
-  skipAuth?: boolean;
 }
 
-const { title, skipAuth = false } = Astro.props;
+const { title } = Astro.props;
 const currentPath = Astro.url.pathname;
 
 const navItems = [
@@ -38,7 +36,7 @@ function isActive(href: string): boolean {
 }
 ---
 
-<html lang="en" data-skip-auth={skipAuth ? 'true' : 'false'}>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -134,23 +132,5 @@ function isActive(href: string): boolean {
 
     <!-- Auth Provider (React Island) -->
     <div id="admin-auth-root"></div>
-
-    {/* Auth verification script */}
-    <script>
-      import { verifyToken } from "../lib/auth.ts";
-
-      // Check if we should skip auth (login page sets data attribute)
-      const skipAuth = document.documentElement.dataset.skipAuth === 'true';
-
-      if (!skipAuth) {
-        verifyToken().then(result => {
-          if (!result.valid) {
-            window.location.href = "/admin/login";
-          }
-        }).catch(() => {
-          window.location.href = "/admin/login";
-        });
-      }
-    </script>
   </body>
 </html>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,53 +1,16 @@
 /**
  * Authentication Utilities
- * Handle JWT token storage and management in the browser
+ * Auth now uses HTTP-only cookies set by server
  */
-
-const TOKEN_KEY = 'career_admin_token';
 
 export interface AuthUser {
   username: string;
 }
 
 export interface LoginResponse {
-  token: string;
+  success: boolean;
   user: AuthUser;
   expiresIn: number;
-}
-
-/**
- * Store auth token in localStorage
- */
-export function setAuthToken(token: string): void {
-  if (typeof window !== 'undefined') {
-    localStorage.setItem(TOKEN_KEY, token);
-  }
-}
-
-/**
- * Get auth token from localStorage
- */
-export function getAuthToken(): string | null {
-  if (typeof window !== 'undefined') {
-    return localStorage.getItem(TOKEN_KEY);
-  }
-  return null;
-}
-
-/**
- * Remove auth token from localStorage
- */
-export function clearAuthToken(): void {
-  if (typeof window !== 'undefined') {
-    localStorage.removeItem(TOKEN_KEY);
-  }
-}
-
-/**
- * Check if user is authenticated (has token)
- */
-export function isAuthenticated(): boolean {
-  return getAuthToken() !== null;
 }
 
 /**
@@ -59,6 +22,7 @@ export async function login(username: string, password: string): Promise<LoginRe
     headers: {
       'Content-Type': 'application/json',
     },
+    credentials: 'include', // Include cookies
     body: JSON.stringify({ username, password }),
   });
 
@@ -67,104 +31,40 @@ export async function login(username: string, password: string): Promise<LoginRe
     throw new Error(error.error || 'Login failed');
   }
 
-  const data: LoginResponse = await response.json();
-
-  // Store token
-  setAuthToken(data.token);
-
-  return data;
+  return await response.json();
 }
 
 /**
  * Logout user
  */
 export async function logout(): Promise<void> {
-  const token = getAuthToken();
-
-  if (token) {
-    try {
-      await fetch('/.netlify/functions/auth-logout', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-    } catch (error) {
-      console.error('Logout request failed:', error);
-      // Continue with client-side logout anyway
-    }
+  try {
+    await fetch('/.netlify/functions/auth-logout', {
+      method: 'POST',
+      credentials: 'include',
+    });
+  } catch (error) {
+    console.error('Logout request failed:', error);
   }
-
-  // Clear token regardless of server response
-  clearAuthToken();
 }
 
 /**
  * Verify if token is still valid
  */
 export async function verifyToken(): Promise<{ valid: boolean; user?: AuthUser }> {
-  const token = getAuthToken();
-
-  if (!token) {
-    return { valid: false };
-  }
-
   try {
     const response = await fetch('/.netlify/functions/auth-verify', {
-      method: 'GET',
-      headers: {
-        'Authorization': `Bearer ${token}`,
-      },
+      method: 'POST',
+      credentials: 'include',
     });
 
     if (!response.ok) {
-      clearAuthToken();
       return { valid: false };
     }
 
-    const data = await response.json();
-    return { valid: data.valid, user: data.user };
+    return await response.json();
   } catch (error) {
     console.error('Token verification failed:', error);
-    clearAuthToken();
     return { valid: false };
   }
-}
-
-/**
- * Get authorization header for API requests
- */
-export function getAuthHeader(): { Authorization: string } | Record<string, never> {
-  const token = getAuthToken();
-  if (token) {
-    return { Authorization: `Bearer ${token}` };
-  }
-  return {};
-}
-
-/**
- * Make authenticated API request
- */
-export async function authenticatedFetch(url: string, options: RequestInit = {}): Promise<Response> {
-  const token = getAuthToken();
-
-  if (!token) {
-    throw new Error('No authentication token');
-  }
-
-  const response = await fetch(url, {
-    ...options,
-    headers: {
-      ...options.headers,
-      'Authorization': `Bearer ${token}`,
-    },
-  });
-
-  // If unauthorized, clear token and throw error
-  if (response.status === 401) {
-    clearAuthToken();
-    throw new Error('Authentication expired');
-  }
-
-  return response;
 }

--- a/src/lib/graphql-client.ts
+++ b/src/lib/graphql-client.ts
@@ -4,7 +4,6 @@
  */
 
 import { GraphQLClient } from 'graphql-request';
-import { getAuthToken } from './auth';
 
 // For client-side (admin UI)
 const GRAPHQL_ENDPOINT = import.meta.env.PUBLIC_GRAPHQL_ENDPOINT;
@@ -13,20 +12,17 @@ const API_KEY = import.meta.env.PUBLIC_API_KEY || '';
 /**
  * Create a GraphQL client for runtime use (admin UI)
  * This uses PUBLIC_ prefixed env vars that are available client-side
- * Includes auth token for mutation authorization
  */
 export function createGraphQLClient(): GraphQLClient {
   if (!GRAPHQL_ENDPOINT) {
     throw new Error('PUBLIC_GRAPHQL_ENDPOINT environment variable is required');
   }
 
-  const token = getAuthToken();
-
   return new GraphQLClient(GRAPHQL_ENDPOINT, {
     headers: {
       'X-API-Key': API_KEY,
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
+    credentials: 'include', // Include cookies for auth
   });
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,33 @@
+import { defineMiddleware } from 'astro:middleware';
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const { url, cookies, redirect } = context;
+  
+  // Check if this is an admin page (but not login)
+  if (url.pathname.startsWith('/admin') && url.pathname !== '/admin/login') {
+    const token = cookies.get('auth_token')?.value;
+    
+    if (!token) {
+      return redirect('/admin/login', 302);
+    }
+
+    // Verify token
+    try {
+      const response = await fetch(`${url.origin}/.netlify/functions/auth-verify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token })
+      });
+
+      const result = await response.json();
+      
+      if (!response.ok || !result.valid) {
+        return redirect('/admin/login', 302);
+      }
+    } catch (error) {
+      return redirect('/admin/login', 302);
+    }
+  }
+
+  return next();
+});


### PR DESCRIPTION
## Problem
Admin pages were loading before authentication check, causing a flash of content before redirecting to login. This happened because auth was checked client-side after the page rendered.

## Solution
- Moved auth from client-side to **server-side using Astro middleware**
- Replaced localStorage tokens with **HTTP-only cookies** for better security
- Added  to intercept  routes before rendering
- Updated all auth functions to set/read cookies instead of tokens
- Made Secure flag conditional (disabled in dev, enabled in production)

## Changes
- ✅ No more page flash - auth checked before rendering
- ✅ More secure - HTTP-only cookies can't be accessed by JavaScript
- ✅ Works in local dev (no Secure flag) and production (with Secure flag)
- ✅ Simplified auth flow - middleware handles all admin routes

## Testing
- [x] Login works and sets cookie
- [x] Admin pages redirect to login when not authenticated
- [x] No page flash on unauthorized access
- [x] Logout clears cookie properly