### PR TITLE
fix: project detail page writing samples and type key fixes

### DIFF
--- a/src/components/admin/pages/ProjectDetailPage.tsx
+++ b/src/components/admin/pages/ProjectDetailPage.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
-import { getGraphQLClient } from '../../../lib/graphql-client';
-import { PROJECT_QUERY, DELETE_PROJECT_MUTATION } from '../../../lib/graphql';
-import type { Project } from '../../../lib/types';
-import { Button, Card, Badge } from '../ui';
-import { ConfirmModal } from '../ui/Modal';
+import { useState, useEffect } from "react";
+import { getGraphQLClient } from "../../../lib/graphql-client";
+import { PROJECT_QUERY, DELETE_PROJECT_MUTATION } from "../../../lib/graphql";
+import type { Project } from "../../../lib/types";
+import { Button, Card, Badge } from "../ui";
+import { ConfirmModal } from "../ui/Modal";
 
 interface ProjectDetailPageProps {
   projectId: string;
@@ -13,7 +13,9 @@ interface ProjectResponse {
   project: Project | null;
 }
 
-export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps) {
+export default function ProjectDetailPage({
+  projectId,
+}: ProjectDetailPageProps) {
   const [project, setProject] = useState<Project | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -29,11 +31,13 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps)
     setError(null);
     try {
       const client = getGraphQLClient();
-      const data = await client.request<ProjectResponse>(PROJECT_QUERY, { id: projectId });
+      const data = await client.request<ProjectResponse>(PROJECT_QUERY, {
+        id: projectId,
+      });
       setProject(data.project);
     } catch (err) {
-      console.error('Failed to fetch project:', err);
-      setError(err instanceof Error ? err.message : 'Failed to fetch project');
+      console.error("Failed to fetch project:", err);
+      setError(err instanceof Error ? err.message : "Failed to fetch project");
     } finally {
       setIsLoading(false);
     }
@@ -44,10 +48,10 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps)
     try {
       const client = getGraphQLClient();
       await client.request(DELETE_PROJECT_MUTATION, { id: projectId });
-      window.location.href = '/admin/projects';
+      window.location.href = "/admin/projects";
     } catch (err) {
-      console.error('Failed to delete project:', err);
-      setError(err instanceof Error ? err.message : 'Failed to delete project');
+      console.error("Failed to delete project:", err);
+      setError(err instanceof Error ? err.message : "Failed to delete project");
       setIsDeleting(false);
       setShowDeleteModal(false);
     }
@@ -85,18 +89,27 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps)
         <div className="flex justify-between items-start">
           <div>
             <div className="flex items-center gap-3 mb-2">
-              <h2 className="text-2xl font-bold text-text-primary">{project.name}</h2>
+              <h2 className="text-2xl font-bold text-text-primary">
+                {project.name}
+              </h2>
               <Badge>{project.type}</Badge>
               {project.featured && <Badge variant="primary">Featured</Badge>}
             </div>
             {project.date && (
-              <p className="text-text-muted">{new Date(project.date).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}</p>
+              <p className="text-text-muted">
+                {new Date(project.date).toLocaleDateString("en-US", {
+                  month: "long",
+                  year: "numeric",
+                })}
+              </p>
             )}
           </div>
           <div className="flex gap-2">
             <Button
               variant="secondary"
-              onClick={() => window.location.href = `/admin/projects/${projectId}/edit`}
+              onClick={() =>
+                (window.location.href = `/admin/projects/${projectId}/edit`)
+              }
             >
               Edit
             </Button>
@@ -113,7 +126,9 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps)
         {/* Overview */}
         <Card>
           <div className="p-6">
-            <h3 className="text-lg font-semibold text-text-primary mb-3">Overview</h3>
+            <h3 className="text-lg font-semibold text-text-primary mb-3">
+              Overview
+            </h3>
             <p className="text-text-secondary">{project.overview}</p>
           </div>
         </Card>
@@ -124,24 +139,36 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps)
             {project.challenge && (
               <Card>
                 <div className="p-6">
-                  <h3 className="text-lg font-semibold text-text-primary mb-3">Challenge</h3>
-                  <p className="text-text-secondary text-sm">{project.challenge}</p>
+                  <h3 className="text-lg font-semibold text-text-primary mb-3">
+                    Challenge
+                  </h3>
+                  <p className="text-text-secondary text-sm">
+                    {project.challenge}
+                  </p>
                 </div>
               </Card>
             )}
             {project.approach && (
               <Card>
                 <div className="p-6">
-                  <h3 className="text-lg font-semibold text-text-primary mb-3">Approach</h3>
-                  <p className="text-text-secondary text-sm">{project.approach}</p>
+                  <h3 className="text-lg font-semibold text-text-primary mb-3">
+                    Approach
+                  </h3>
+                  <p className="text-text-secondary text-sm">
+                    {project.approach}
+                  </p>
                 </div>
               </Card>
             )}
             {project.outcome && (
               <Card>
                 <div className="p-6">
-                  <h3 className="text-lg font-semibold text-text-primary mb-3">Outcome</h3>
-                  <p className="text-text-secondary text-sm">{project.outcome}</p>
+                  <h3 className="text-lg font-semibold text-text-primary mb-3">
+                    Outcome
+                  </h3>
+                  <p className="text-text-secondary text-sm">
+                    {project.outcome}
+                  </p>
                 </div>
               </Card>
             )}
@@ -152,7 +179,9 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps)
         {project.impact && (
           <Card>
             <div className="p-6">
-              <h3 className="text-lg font-semibold text-text-primary mb-3">Impact</h3>
+              <h3 className="text-lg font-semibold text-text-primary mb-3">
+                Impact
+              </h3>
               <p className="text-text-secondary">{project.impact}</p>
             </div>
           </Card>
@@ -162,10 +191,12 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps)
         {project.roleTypes && project.roleTypes.length > 0 && (
           <Card>
             <div className="p-6">
-              <h3 className="text-lg font-semibold text-text-primary mb-3">Role Types</h3>
+              <h3 className="text-lg font-semibold text-text-primary mb-3">
+                Role Types
+              </h3>
               <div className="flex flex-wrap gap-2">
                 {project.roleTypes.map((role) => (
-                  <Badge key={role}>{role.replace(/_/g, ' ')}</Badge>
+                  <Badge key={role}>{role.replace(/_/g, " ")}</Badge>
                 ))}
               </div>
             </div>
@@ -176,7 +207,9 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps)
         {project.technologies && project.technologies.length > 0 && (
           <Card>
             <div className="p-6">
-              <h3 className="text-lg font-semibold text-text-primary mb-3">Technologies</h3>
+              <h3 className="text-lg font-semibold text-text-primary mb-3">
+                Technologies
+              </h3>
               <div className="flex flex-wrap gap-2">
                 {project.technologies.map((tech) => (
                   <span
@@ -195,7 +228,9 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps)
         {project.links && project.links.length > 0 && (
           <Card>
             <div className="p-6">
-              <h3 className="text-lg font-semibold text-text-primary mb-3">Links</h3>
+              <h3 className="text-lg font-semibold text-text-primary mb-3">
+                Links
+              </h3>
               <div className="space-y-2">
                 {project.links.map((link, index) => (
                   <a
@@ -206,29 +241,20 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailPageProps)
                     className="flex items-center gap-2 text-accent-blue hover:underline"
                   >
                     <span>{link.linkText || link.type}</span>
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                      />
                     </svg>
                   </a>
-                ))}
-              </div>
-            </div>
-          </Card>
-        )}
-
-        {/* Keywords */}
-        {project.keywords && project.keywords.length > 0 && (
-          <Card>
-            <div className="p-6">
-              <h3 className="text-lg font-semibold text-text-primary mb-3">Keywords</h3>
-              <div className="flex flex-wrap gap-2">
-                {project.keywords.map((keyword) => (
-                  <span
-                    key={keyword}
-                    className="px-3 py-1 bg-accent-blue/20 text-accent-blue rounded-full text-sm"
-                  >
-                    {keyword}
-                  </span>
                 ))}
               </div>
             </div>

--- a/src/components/pages/ProjectDetailPageContent.tsx
+++ b/src/components/pages/ProjectDetailPageContent.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
-import { getGraphQLClient } from '../../lib/graphql-client';
-import { PROJECT_QUERY } from '../../lib/graphql';
-import type { Project, ProjectResponse } from '../../lib/types';
+import { useState, useEffect } from "react";
+import { getGraphQLClient } from "../../lib/graphql-client";
+import { PROJECT_QUERY } from "../../lib/graphql";
+import type { Project, ProjectResponse } from "../../lib/types";
 
 export default function ProjectDetailPageContent() {
   const [project, setProject] = useState<Project | null>(null);
@@ -14,7 +14,7 @@ export default function ProjectDetailPageContent() {
 
   const fetchProject = async () => {
     try {
-      const pathParts = window.location.pathname.split('/');
+      const pathParts = window.location.pathname.split("/");
       const id = pathParts[pathParts.length - 1];
 
       const client = getGraphQLClient();
@@ -23,28 +23,37 @@ export default function ProjectDetailPageContent() {
       if (data.project) {
         setProject(data.project);
       } else {
-        setError('Project not found');
+        setError("Project not found");
       }
     } catch (err) {
-      console.error('Failed to fetch project:', err);
-      setError(err instanceof Error ? err.message : 'Failed to fetch project');
+      console.error("Failed to fetch project:", err);
+      setError(err instanceof Error ? err.message : "Failed to fetch project");
     } finally {
       setIsLoading(false);
     }
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'long',
-      year: 'numeric',
+    return new Date(dateString).toLocaleDateString("en-US", {
+      month: "long",
+      year: "numeric",
     });
   };
 
   const getProjectType = (type: string) => {
     const types: Record<string, { label: string; colorClass: string }> = {
-      engineering: { label: 'Engineering', colorClass: 'bg-accent-blue/20 text-accent-blue' },
-      writing: { label: 'Writing', colorClass: 'bg-accent-green/20 text-accent-green' },
-      leadership: { label: 'Leadership', colorClass: 'bg-accent-purple/20 text-accent-purple' },
+      software_engineering: {
+        label: "Engineering",
+        colorClass: "bg-accent-blue/20 text-accent-blue",
+      },
+      technical_writing: {
+        label: "Writing",
+        colorClass: "bg-accent-green/20 text-accent-green",
+      },
+      leadership: {
+        label: "Leadership",
+        colorClass: "bg-accent-purple/20 text-accent-purple",
+      },
     };
     return types[type] || types.engineering;
   };
@@ -61,7 +70,9 @@ export default function ProjectDetailPageContent() {
     return (
       <div className="max-w-2xl mx-auto py-12 px-4">
         <div className="p-6 bg-dark-card border border-dark-border rounded-lg text-center">
-          <p className="text-accent-pink mb-4">{error || 'Project not found'}</p>
+          <p className="text-accent-pink mb-4">
+            {error || "Project not found"}
+          </p>
           <a
             href="/projects"
             className="inline-block px-4 py-2 bg-accent-blue text-text-inverse rounded-lg hover:bg-accent-blue/80 transition-colors"
@@ -77,32 +88,75 @@ export default function ProjectDetailPageContent() {
   const links = project.links ?? [];
 
   const getLinkIcon = (type: string) => {
-    if (type === 'github') {
+    if (type === "github") {
       return (
-        <svg className="w-5 h-5 shrink-0" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <svg
+          className="w-5 h-5 shrink-0"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
           <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
         </svg>
       );
     }
-    if (type === 'website') {
+    if (type === "website") {
       return (
-        <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
+        <svg
+          className="w-5 h-5 shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
+          />
         </svg>
       );
     }
-    if (type === 'demo' || type.startsWith('demo')) {
+    if (type === "demo" || type.startsWith("demo")) {
       return (
-        <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+        <svg
+          className="w-5 h-5 shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+          />
         </svg>
       );
     }
     // Default: link icon
     return (
-      <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+      <svg
+        className="w-5 h-5 shrink-0"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+        />
       </svg>
     );
   };
@@ -116,26 +170,45 @@ export default function ProjectDetailPageContent() {
             href="/projects"
             className="inline-flex items-center gap-2 text-accent-blue hover:text-accent-blue/80 transition-colors"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
             </svg>
             Back to Projects
           </a>
         </div>
 
-        <h1 className="text-4xl font-bold text-text-primary mb-4">{project.name}</h1>
+        <h1 className="text-4xl font-bold text-text-primary mb-4">
+          {project.name}
+        </h1>
 
         <div className="flex flex-wrap items-center gap-4 mb-6">
-          <span className={`px-3 py-1 rounded-full text-sm font-medium ${typeInfo.colorClass}`}>
+          <span
+            className={`px-3 py-1 rounded-full text-sm font-medium ${typeInfo.colorClass}`}
+          >
             {typeInfo.label}
           </span>
 
-          {project.date && <span className="text-text-secondary">{formatDate(project.date)}</span>}
-
+          {project.date && (
+            <span className="text-text-secondary">
+              {formatDate(project.date)}
+            </span>
+          )}
         </div>
 
         {project.overview && (
-          <p className="text-xl text-text-secondary leading-relaxed">{project.overview}</p>
+          <p className="text-xl text-text-secondary leading-relaxed">
+            {project.overview}
+          </p>
         )}
       </div>
 
@@ -146,39 +219,57 @@ export default function ProjectDetailPageContent() {
           {/* Challenge */}
           {project.challenge && (
             <section>
-              <h2 className="text-2xl font-semibold text-text-primary mb-4">The Challenge</h2>
-              <p className="text-text-secondary leading-relaxed">{project.challenge}</p>
+              <h2 className="text-2xl font-semibold text-text-primary mb-4">
+                The Challenge
+              </h2>
+              <p className="text-text-secondary leading-relaxed">
+                {project.challenge}
+              </p>
             </section>
           )}
 
           {/* Approach */}
           {project.approach && (
             <section>
-              <h2 className="text-2xl font-semibold text-text-primary mb-4">Approach</h2>
-              <p className="text-text-secondary leading-relaxed">{project.approach}</p>
+              <h2 className="text-2xl font-semibold text-text-primary mb-4">
+                Approach
+              </h2>
+              <p className="text-text-secondary leading-relaxed">
+                {project.approach}
+              </p>
             </section>
           )}
 
           {/* Outcome */}
           {project.outcome && (
             <section>
-              <h2 className="text-2xl font-semibold text-text-primary mb-4">Outcome</h2>
-              <p className="text-text-secondary leading-relaxed">{project.outcome}</p>
+              <h2 className="text-2xl font-semibold text-text-primary mb-4">
+                Outcome
+              </h2>
+              <p className="text-text-secondary leading-relaxed">
+                {project.outcome}
+              </p>
             </section>
           )}
 
           {/* Impact */}
           {project.impact && (
             <section>
-              <h2 className="text-2xl font-semibold text-text-primary mb-4">Impact</h2>
-              <p className="text-text-secondary leading-relaxed">{project.impact}</p>
+              <h2 className="text-2xl font-semibold text-text-primary mb-4">
+                Impact
+              </h2>
+              <p className="text-text-secondary leading-relaxed">
+                {project.impact}
+              </p>
             </section>
           )}
 
           {/* Technologies Used */}
           {project.technologies && project.technologies.length > 0 && (
             <section>
-              <h2 className="text-2xl font-semibold text-text-primary mb-4">Technologies</h2>
+              <h2 className="text-2xl font-semibold text-text-primary mb-4">
+                Technologies
+              </h2>
               <div className="flex flex-wrap gap-2">
                 {project.technologies.map((tech) => (
                   <span
@@ -198,20 +289,28 @@ export default function ProjectDetailPageContent() {
           {/* Links Card */}
           {links.length > 0 && (
             <div className="bg-dark-card rounded-xl p-6 border border-dark-border">
-              <h3 className="text-lg font-semibold text-text-primary mb-4">Project Links</h3>
+              <h3 className="text-lg font-semibold text-text-primary mb-4">
+                Project Links
+              </h3>
               <div className="space-y-3">
-                {links.map((link, idx) => (
-                  <a
-                    key={idx}
-                    href={link.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-3 text-text-secondary hover:text-accent-blue transition-colors"
-                  >
-                    {getLinkIcon(link.type)}
-                    {link.linkText || link.type}
-                  </a>
-                ))}
+                {links.map((link, idx) =>
+                  link.type === "writing_sample" ? (
+                    <p key={idx} className="text-text-secondary text-sm italic">
+                      Writing samples available upon request
+                    </p>
+                  ) : (
+                    <a
+                      key={idx}
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-3 text-text-secondary hover:text-accent-blue transition-colors"
+                    >
+                      {getLinkIcon(link.type)}
+                      {link.linkText || link.type}
+                    </a>
+                  ),
+                )}
               </div>
             </div>
           )}
@@ -219,18 +318,20 @@ export default function ProjectDetailPageContent() {
           {/* Role Types */}
           {project.roleTypes && project.roleTypes.length > 0 && (
             <div className="bg-dark-card rounded-xl p-6 border border-dark-border">
-              <h3 className="text-lg font-semibold text-text-primary mb-4">Focus Areas</h3>
+              <h3 className="text-lg font-semibold text-text-primary mb-4">
+                Focus Areas
+              </h3>
               <div className="flex flex-wrap gap-2">
                 {project.roleTypes.map((role) => (
                   <span
                     key={role}
                     className={`px-2 py-1 text-xs font-medium rounded ${
-                      role.includes('engineer')
-                        ? 'bg-accent-blue/20 text-accent-blue'
-                        : 'bg-accent-green/20 text-accent-green'
+                      role.includes("engineer")
+                        ? "bg-accent-blue/20 text-accent-blue"
+                        : "bg-accent-green/20 text-accent-green"
                     }`}
                   >
-                    {role.replace(/_/g, ' ')}
+                    {role.replace(/_/g, " ")}
                   </span>
                 ))}
               </div>


### PR DESCRIPTION
## Summary

- Render "Writing samples available upon request" text for links with `type === "writing_sample"` instead of a broken anchor tag
- Fix project type map keys from `engineering`/`writing` to `software_engineering`/`technical_writing` to match API values
- Remove Keywords section from admin `ProjectDetailPage` (keywords removed from data model)

## Test plan

- [ ] Open a project with a `writing_sample` link — verify the text message renders instead of a link
- [ ] Verify project type badge renders correctly for `software_engineering` and `technical_writing` project types
- [ ] Verify admin project detail page no longer shows a Keywords section

🤖 Generated with [Claude Code](https://claude.com/claude-code)